### PR TITLE
BF: Base scanpath simplification on per-iteration changes

### DIFF
--- a/multimatch_gaze/multimatch_gaze.py
+++ b/multimatch_gaze/multimatch_gaze.py
@@ -335,13 +335,15 @@ def simplify_scanpath(path, TAmp, TDir, TDur):
 
     :return: eyedata: dict, simplified vector-based scanpath representation
     """
-    looptime = 0
+    prev_length = len(path["fix"]["dur"])
     while True:
         path = simdir(path, TDir, TDur)
         path = simlen(path, TAmp, TDur)
-        looptime += 1
-        if looptime == len(path["fix"]["dur"]):
+        length = len(path["fix"]["dur"])
+        if length == prev_length:
             return path
+        else:
+            prev_length = length
 
 
 def cal_vectordifferences(path1, path2):


### PR DESCRIPTION
Previously, the amount of iterations during simplification was based on the length of the scanpath.
Scanpath simplification stopped if the number of iterations was equal to the scanpath length.
This logic fails in cases where the scanpath length drops lower than the amount of iterations without ever equaling it (#46)
This change bases the decision to terminate the simplification on the condition that no length reduction
(and thus no simplification) has happened in the previous iteration.

Thanks to @LFaggi for the bug report and code patch. Fixes #46